### PR TITLE
Fix empty PERCENT_I variable.

### DIFF
--- a/xwp_audit
+++ b/xwp_audit
@@ -25,7 +25,7 @@ if [ -z "$LINES" ]; then
 fi
 
 PERCENT_F=$(echo "$ERRORS / $LINES * 100" | bc -l | bc)
-PERCENT_I=${PERCENT_F%.*}
+PERCENT_I=$(printf "%d\n" "$PERCENT_F" 2>/dev/null) # Truncates the fraction.
 
 echo "Coding standards result:"
 


### PR DESCRIPTION
${PERCENT_F%.*} will result in null if PERCENT_F is less than 1.
Instead, using printf to help we can just truncate the fraction.
